### PR TITLE
Implementação referentes a aula 3 de compiladores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .vscode/
+
+mybc
+mybc.o
+lexer.o
+parser.o

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -I. -g
 
-relocatable = mybc.o lexer.o
+relocatable = mybc.o lexer.o parser.o
 
 mybc: $(relocatable)
 	$(CC) -o mybc $(relocatable)

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,6 @@ mybc: $(relocatable)
 
 clean:
 	$(RM) *.o
+
+mostlyclean: clean
+	$(RM) *~ mybc

--- a/lexer.c
+++ b/lexer.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <lexer.h>
 
+char lexeme[MAX_ID_LEN + 1];
 
 int lineNum = 1;
 

--- a/lexer.c
+++ b/lexer.c
@@ -166,7 +166,7 @@ int is_HEX(FILE *p_tape)
 
     int prefixHexIndicator = getc(p_tape);
 
-    if (!is_hex_indicator(p_tape))
+    if (!is_hex_indicator(prefixHexIndicator))
     {
         ungetc(prefixHexIndicator, p_tape); //put the character read back in the tape
         ungetc(prefixZero, p_tape);         //put the prefix back in the tape

--- a/lexer.h
+++ b/lexer.h
@@ -1,3 +1,6 @@
+#ifndef LEXER_H
+#define LEXER_H
+
 #include <stdio.h>
 
 typedef enum {
@@ -7,6 +10,10 @@ typedef enum {
     HEX,
 } EToken;
 
+#define MAX_ID_LEN 32
+
 extern int lineNum;
 
 extern int lxr_get_token(FILE *p_source);
+
+#endif

--- a/lexer.h
+++ b/lexer.h
@@ -13,6 +13,7 @@ typedef enum {
 #define MAX_ID_LEN 32
 
 extern int lineNum;
+extern char lexeme[];
 
 extern int lxr_get_token(FILE *p_source);
 

--- a/mybc.c
+++ b/mybc.c
@@ -2,9 +2,11 @@
 #include <parser.h>
 #include <lexer.h>
 
+FILE *pSource;
+
 int main() 
 {
-    FILE *pSource = stdin;
+    pSource = stdin;
 
     look_ahead = lxr_get_token(pSource);
     

--- a/parser.c
+++ b/parser.c
@@ -2,88 +2,93 @@
 #include <lexer.h>
 #include <parser.h>
 
+#define PLUS '+'
+#define MINUS '-'
+#define TIMES '*'
+#define DIV '/'
+#define L_PAREN '('
+#define R_PAREN ')'
+
 int look_ahead;
+
+int is_oplus(int c);
+int is_otimes(int c);
+
+#pragma region Public Functions 
 
 void psr_E(void)
 {
-    if (look_ahead == '+' || look_ahead == '-')
+    int oplus = 0;
+    int otimes = 0;
+    int signal = 0;
+    
+    if (is_oplus(look_ahead))
     {
+       !(look_ahead == MINUS) || (signal = look_ahead);
        psr_match(look_ahead);
     }
     
-    psr_T();
-    psr_R();
-}
-
-
-void psr_T(void)
-{
-    psr_F();
-    psr_Q();
-}
-
-
-void psr_F(void)
-{
+_T:
+    otimes = 0;
+_F:
     switch (look_ahead)
     {
-        case '(':
-            psr_match('(');
+        case L_PAREN:
+            psr_match(L_PAREN);
             psr_E();
-            psr_match(')');
+            psr_match(R_PAREN);
             break;
         
         case DEC:
+            printf("\t%s\n", lexeme);
             psr_match(DEC);
             break;
 
         case OCT:
+            printf("\t%s\n", lexeme);
             psr_match(OCT);
             break;
 
         case HEX:
+            printf("\t%s\n", lexeme);
             psr_match(HEX);
             break;
 
         default:
+            printf("\t%s\n", lexeme);
             psr_match(ID);
     }
-}
 
-psr_R(void)
-{
-    switch (look_ahead)
+    if (otimes)
     {
-        case '+':
-            psr_match('+');
-            psr_T();
-            psr_R();
-            break;
-
-        case '-':
-            psr_match('-');
-            psr_T();
-            psr_R();
-            break;
+        printf("\t%c\n", otimes);
+        otimes = 0;
     }
-}
 
-
-void psr_Q(void)
-{
-    switch (look_ahead)
+    if (is_otimes(look_ahead))
     {
-        case '*':
-            psr_match('*');
-            psr_F();
-            psr_Q();
-            break;
+        otimes = look_ahead;
+        psr_match(look_ahead);
+        goto _F;
+    }
 
-        case '/':
-            psr_match('/');
-            psr_F();
-            psr_Q();
-            break;
+    if (signal)
+    {
+        printf("\tneg\n");
+        signal = 0;
+    }
+
+    if (oplus)
+    {
+        printf("\t%c\n", oplus);
+        oplus = 0;
+    }
+
+    if (is_oplus(look_ahead))
+    {
+        oplus = look_ahead;
+        psr_match(look_ahead);
+        goto _T;
     }
 }
 
@@ -99,3 +104,19 @@ void psr_match(int expected)
         exit(-1);
     }
 }
+
+#pragma endregion
+
+#pragma region Private Functions
+
+int is_oplus(int c)
+{
+    return c == PLUS || c == MINUS;
+}
+
+int is_otimes(int c)
+{
+    return c == TIMES || c == DIV;
+}
+
+#pragma endregion

--- a/parser.h
+++ b/parser.h
@@ -1,12 +1,14 @@
+#ifndef PARSER_H
+#define PARSER_H
+
 #include <stdio.h>
 #include <stdlib.h>
 
-extern void psr_match(int expected);
 extern FILE *pSource;
 extern int look_ahead;
 
+extern void psr_match(int expected);
+
 void psr_E(void);
-void psr_T(void);
-void psr_F(void);
-void psr_R(void);
-void psr_Q(void);
+
+#endif


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve the lexer and parser functionalities. The most important changes include adding new files to the build process, defining constants and global variables, and refactoring functions for better readability and maintainability.

### Build Process Improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L3-R12): Added `parser.o` to the `relocatable` variable and introduced a `mostlyclean` target to remove additional temporary files.

### Lexer Enhancements:
* [`lexer.c`](diffhunk://#diff-5a4aeebfe6743d754fcccf0d06dded2063467669d7e4cd55c8f5ed5f43e808b3R5): Introduced a global `lexeme` array to store lexemes.
* [`lexer.c`](diffhunk://#diff-5a4aeebfe6743d754fcccf0d06dded2063467669d7e4cd55c8f5ed5f43e808b3L168-R169): Fixed a bug in the `is_HEX` function by correctly passing the `prefixHexIndicator` to `is_hex_indicator`.
* [`lexer.h`](diffhunk://#diff-7b03ad4c1755c60ef19d74925fcb0149b570cb094ebbdee034e8372e1b553aa4R1-R3): Added header guards and defined `MAX_ID_LEN` along with the declaration of the `lexeme` array. [[1]](diffhunk://#diff-7b03ad4c1755c60ef19d74925fcb0149b570cb094ebbdee034e8372e1b553aa4R1-R3) [[2]](diffhunk://#diff-7b03ad4c1755c60ef19d74925fcb0149b570cb094ebbdee034e8372e1b553aa4R13-R20)

### Parser Improvements:
* [`parser.c`](diffhunk://#diff-65f1a082f56ebd52b4eaabdbe54d6e516736c8d9186b8c82c8ca55ad3cac105eR5-R91): Defined constants for operators and refactored the `psr_E` function to improve readability and maintainability.
* [`parser.c`](diffhunk://#diff-65f1a082f56ebd52b4eaabdbe54d6e516736c8d9186b8c82c8ca55ad3cac105eR107-R122): Added private helper functions `is_oplus` and `is_otimes` to check for operator types.
* [`parser.h`](diffhunk://#diff-33b87b12899853d2f9e1488506d40f1894a535a92c160fdc2460f25cb751f498R1-R14): Added header guards and reorganized function declarations.

### Miscellaneous:
* [`mybc.c`](diffhunk://#diff-6d79d1bf6b634eb2d86ba572731a64c2f716cdfd209e9a94d8567f19bc594feeR5-R9): Made `pSource` a global variable instead of declaring it inside the `main` function.