### PR TITLE
Implementacoes referens a aula 5

### DIFF
--- a/lexer.h
+++ b/lexer.h
@@ -12,7 +12,6 @@ typedef enum {
 
 #define MAX_ID_LEN 32
 
-extern int lineNum;
 extern char lexeme[];
 
 extern int lxr_get_token(FILE *p_source);

--- a/mybc.c
+++ b/mybc.c
@@ -12,8 +12,6 @@ int main()
     
     psr_E();
 
-    printf("\t%d\n", lineNum);
-
     return 0;
 }
 

--- a/parser.c
+++ b/parser.c
@@ -25,7 +25,7 @@ void psr_E(void)
     if (is_oplus(look_ahead))
     {
        !(look_ahead == MINUS) || (signal = look_ahead);
-       psr_match(look_ahead);
+       match(look_ahead);
     }
     
 _T:
@@ -34,29 +34,29 @@ _F:
     switch (look_ahead)
     {
         case L_PAREN:
-            psr_match(L_PAREN);
+            match(L_PAREN);
             psr_E();
-            psr_match(R_PAREN);
+            match(R_PAREN);
             break;
         
         case DEC:
             printf("\t%s\n", lexeme);
-            psr_match(DEC);
+            match(DEC);
             break;
 
         case OCT:
             printf("\t%s\n", lexeme);
-            psr_match(OCT);
+            match(OCT);
             break;
 
         case HEX:
             printf("\t%s\n", lexeme);
-            psr_match(HEX);
+            match(HEX);
             break;
 
         default:
             printf("\t%s\n", lexeme);
-            psr_match(ID);
+            match(ID);
     }
 
     if (otimes)
@@ -68,7 +68,7 @@ _F:
     if (is_otimes(look_ahead))
     {
         otimes = look_ahead;
-        psr_match(look_ahead);
+        match(look_ahead);
         goto _F;
     }
 
@@ -87,12 +87,12 @@ _F:
     if (is_oplus(look_ahead))
     {
         oplus = look_ahead;
-        psr_match(look_ahead);
+        match(look_ahead);
         goto _T;
     }
 }
 
-void psr_match(int expected)
+void match(int expected)
 {
     if (look_ahead == expected)
     {

--- a/parser.h
+++ b/parser.h
@@ -7,8 +7,6 @@
 extern FILE *pSource;
 extern int look_ahead;
 
-extern void psr_match(int expected);
-
-void psr_E(void);
+extern void psr_E(void);
 
 #endif


### PR DESCRIPTION
This pull request includes several changes to the lexer and parser in the codebase. The primary focus is on refactoring the lexer to use a `lexeme` array for token storage and simplifying the parser by renaming a function for consistency.

Lexer improvements:

* Added the `clear_lexeme` function to reset the `lexeme` array. (`lexer.c`) [[1]](diffhunk://#diff-5a4aeebfe6743d754fcccf0d06dded2063467669d7e4cd55c8f5ed5f43e808b3L7-R7) [[2]](diffhunk://#diff-5a4aeebfe6743d754fcccf0d06dded2063467669d7e4cd55c8f5ed5f43e808b3R30-R39)
* Refactored the `is_ID`, `is_DEC`, `is_OCT`, and `is_HEX` functions to use the `lexeme` array for token storage, improving code readability and consistency. (`lexer.c`) [[1]](diffhunk://#diff-5a4aeebfe6743d754fcccf0d06dded2063467669d7e4cd55c8f5ed5f43e808b3L76-R88) [[2]](diffhunk://#diff-5a4aeebfe6743d754fcccf0d06dded2063467669d7e4cd55c8f5ed5f43e808b3L98-R118) [[3]](diffhunk://#diff-5a4aeebfe6743d754fcccf0d06dded2063467669d7e4cd55c8f5ed5f43e808b3L128-L148) [[4]](diffhunk://#diff-5a4aeebfe6743d754fcccf0d06dded2063467669d7e4cd55c8f5ed5f43e808b3L159-R215)
* Removed the `lineNum` variable and its usage, as it was no longer needed. (`lexer.c`, `lexer.h`, `mybc.c`) [[1]](diffhunk://#diff-5a4aeebfe6743d754fcccf0d06dded2063467669d7e4cd55c8f5ed5f43e808b3L7-R7) [[2]](diffhunk://#diff-7b03ad4c1755c60ef19d74925fcb0149b570cb094ebbdee034e8372e1b553aa4L15) [[3]](diffhunk://#diff-6d79d1bf6b634eb2d86ba572731a64c2f716cdfd209e9a94d8567f19bc594feeL15-L16)

Parser simplifications:

* Renamed the `psr_match` function to `match` for consistency and readability. (`parser.c`, `parser.h`) [[1]](diffhunk://#diff-65f1a082f56ebd52b4eaabdbe54d6e516736c8d9186b8c82c8ca55ad3cac105eL28-R28) [[2]](diffhunk://#diff-65f1a082f56ebd52b4eaabdbe54d6e516736c8d9186b8c82c8ca55ad3cac105eL37-R59) [[3]](diffhunk://#diff-65f1a082f56ebd52b4eaabdbe54d6e516736c8d9186b8c82c8ca55ad3cac105eL71-R71) [[4]](diffhunk://#diff-65f1a082f56ebd52b4eaabdbe54d6e516736c8d9186b8c82c8ca55ad3cac105eL90-R95) [[5]](diffhunk://#diff-33b87b12899853d2f9e1488506d40f1894a535a92c160fdc2460f25cb751f498L10-R10)