### PR TITLE
fix: declaracao da funcao match

### DIFF
--- a/parser.h
+++ b/parser.h
@@ -8,5 +8,6 @@ extern FILE *pSource;
 extern int look_ahead;
 
 extern void psr_E(void);
+extern void match(int expected);
 
 #endif


### PR DESCRIPTION
This pull request includes a small change to the `parser.h` file. The change adds a new function declaration for `match`.

* [`parser.h`](diffhunk://#diff-33b87b12899853d2f9e1488506d40f1894a535a92c160fdc2460f25cb751f498R11): Added a new function declaration `void match(int expected);`